### PR TITLE
Fix: issues with validators

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1,8 +1,9 @@
 """Utility functions used throughout clock."""
 
 DEBUG = True
-BREAK_COLOUR = '#8C92AC'  # slate grey, on a break
-RUN_COLOUR = '#B00FFF'  # purple, not on break
+BREAK_COLOUR = "#8C92AC"  # slate grey, on a break
+RUN_COLOUR = "#B00FFF"  # purple, not on break
+ERROR_COLOUR = "#FF0000"  # red, background for error in settings
 
 
 def bc_log(msg: str) -> None:


### PR DESCRIPTION
Spaces in text entries were causing strange "validation errors". Fix these, and a couple of other issues found during testing.

1. format with Black.
2. Remove spaces from values in warning messages, that led to
   "more than 7    minutes long".
3. If there are only spaces in breaks, validation would fail, when it
   should be okay: "no breaks".
   Unfortunately there was no visible "error" because "   " looked
   exactly like "", so to the user, "there's no problem."
4. Change in number of rounds can invalidate the break list (from 13
   rounds to 8 with breaks of "4,9").  So now, changes to the round
   numbers trigger "error check" of breaks to the new round count.
5. Create global variable for "error colour."